### PR TITLE
[Bug] Update structs.py - height property

### DIFF
--- a/Python/Product/PyKinect/PyKinect/pykinect/nui/structs.py
+++ b/Python/Product/PyKinect/PyKinect/pykinect/nui/structs.py
@@ -210,7 +210,7 @@ class PlanarImage(ctypes.c_voidp):
     def height(self):
         desc = _NuiSurfaceDesc()
         PlanarImage._GetLevelDesc(self, 0, ctypes.byref(desc))
-        return desc.height.value
+        return desc.height
         
     @property
     def bytes_per_pixel(self):


### PR DESCRIPTION
Removed `value` attribute from `height` property return value
